### PR TITLE
feature: Implemented the endorser-policy function

### DIFF
--- a/src/controllers/endorser-transaction/EndorserTransactionController.ts
+++ b/src/controllers/endorser-transaction/EndorserTransactionController.ts
@@ -74,11 +74,11 @@ export class EndorserTransactionController extends Controller {
     try {
       if (writeTransaction.schema) {
 
-        const writeSchema = await this.submitSchemaOnLedger(writeTransaction.schema, writeTransaction.endorsedTransaction, writeTransaction.endorserDid);
+        const writeSchema = await this.submitSchemaOnLedger(writeTransaction.schema, writeTransaction.endorsedTransaction);
         return writeSchema;
       } else if (writeTransaction.credentialDefinition) {
 
-        const writeCredDef = await this.submitCredDefOnLedger(writeTransaction.credentialDefinition, writeTransaction.endorsedTransaction, writeTransaction.endorserDid);
+        const writeCredDef = await this.submitCredDefOnLedger(writeTransaction.credentialDefinition, writeTransaction.endorsedTransaction);
         return writeCredDef;
       } else {
 
@@ -105,20 +105,20 @@ export class EndorserTransactionController extends Controller {
       attributes: string[]
     },
     endorsedTransaction?: string,
-    endorserDid?: string
   ) {
     try {
 
+      const { issuerId, name, version, attributes } = schema;
       const { schemaState } = await this.agent.modules.anoncreds.registerSchema({
         options: {
           endorserMode: 'external',
           endorsedTransaction
         },
         schema: {
-          attrNames: schema.attributes,
-          issuerId: schema.issuerId,
-          name: schema.name,
-          version: schema.version
+          attrNames: attributes,
+          issuerId: issuerId,
+          name: name,
+          version: version
         },
       })
 
@@ -146,8 +146,7 @@ export class EndorserTransactionController extends Controller {
       issuerId: string,
       tag: string
     },
-    endorsedTransaction?: string,
-    endorserDid?: string
+    endorsedTransaction?: string
   ) {
     try {
 
@@ -159,9 +158,11 @@ export class EndorserTransactionController extends Controller {
         },
       })
 
-      const indyVdrAnonCredsRegistry = new IndyVdrAnonCredsRegistry()
-      const schemaDetails = await indyVdrAnonCredsRegistry.getSchema(this.agent.context, credentialDefinition.schemaId)
+      console.log("credentialDefinitionState---", credentialDefinitionState)
+      const schemaDetails = await this.agent.modules.anoncreds.getSchema(credentialDefinition.schemaId)
+      console.log("schemaDetails---", schemaDetails)
       const getCredentialDefinitionId = await getUnqualifiedCredentialDefinitionId(credentialDefinitionState.credentialDefinition.issuerId, `${schemaDetails.schemaMetadata.indyLedgerSeqNo}`, credentialDefinition.tag);
+      console.log("getCredentialDefinitionId---", getCredentialDefinitionId)
       if (credentialDefinitionState.state === 'finished' || credentialDefinitionState.state === 'action') {
 
         const indyNamespaceMatch = /did:indy:([^:]+:?(mainnet|testnet)?:?)/.exec(credentialDefinition.issuerId);

--- a/src/controllers/endorser-transaction/EndorserTransactionController.ts
+++ b/src/controllers/endorser-transaction/EndorserTransactionController.ts
@@ -1,0 +1,183 @@
+import { Agent, AriesFrameworkError } from "@aries-framework/core"
+import { Body, Controller, Post, Res, Route, Tags, TsoaResponse } from "tsoa"
+import { injectable } from "tsyringe"
+import { DidNymTransaction, EndorserTransaction, WriteTransaction } from "../types"
+import { SchemaId, Version } from "../examples"
+import { AnonCredsCredentialDefinition, getUnqualifiedCredentialDefinitionId, getUnqualifiedSchemaId } from "@aries-framework/anoncreds"
+import { IndyVdrAnonCredsRegistry, IndyVdrDidCreateOptions } from "@aries-framework/indy-vdr"
+
+@Tags('EndorserTransaction')
+@Route('/transactions')
+@injectable()
+export class EndorserTransactionController extends Controller {
+  private agent: Agent
+
+  public constructor(agent: Agent) {
+    super()
+    this.agent = agent
+  }
+
+  @Post('/endorse')
+  public async endorserTransaction(
+    @Body() endorserTransaction: EndorserTransaction,
+    @Res() internalServerError: TsoaResponse<500, { message: string }>,
+    @Res() forbiddenError: TsoaResponse<400, { reason: string }>
+  ) {
+    try {
+      const signedTransaction = await this.agent.modules.indyVdr.endorseTransaction(
+        endorserTransaction.transaction,
+        endorserTransaction.endorserDid
+      )
+
+      return { signedTransaction };
+    } catch (error) {
+      if (error instanceof AriesFrameworkError) {
+        if (error.message.includes('UnauthorizedClientRequest')) {
+          return forbiddenError(400, {
+            reason: 'this action is not allowed.',
+          })
+        }
+      }
+      return internalServerError(500, { message: `something went wrong: ${error}` })
+    }
+  }
+
+  @Post('/set-endorser-role')
+  public async didNymTransaction(
+    @Body() didNymTransaction: DidNymTransaction,
+    @Res() internalServerError: TsoaResponse<500, { message: string }>
+  ) {
+    try {
+      const didCreateSubmitResult = await this.agent.dids.create<IndyVdrDidCreateOptions>({
+        did: didNymTransaction.did,
+        options: {
+          endorserMode: 'external',
+          endorsedTransaction: {
+            nymRequest: didNymTransaction.nymRequest,
+          },
+        }
+      })
+
+      return didCreateSubmitResult
+    } catch (error) {
+      return internalServerError(500, { message: `something went wrong: ${error}` })
+    }
+  }
+
+  @Post('/write')
+  public async writeSchemaAndCredDefOnLedger(
+    @Res() forbiddenError: TsoaResponse<400, { reason: string }>,
+    @Res() internalServerError: TsoaResponse<500, { message: string }>,
+    @Body()
+    writeTransaction: WriteTransaction
+  ) {
+    try {
+      if (writeTransaction.schema) {
+
+        const writeSchema = await this.submitSchemaOnLedger(writeTransaction.schema, writeTransaction.endorsedTransaction, writeTransaction.endorserDid);
+        return writeSchema;
+      } else if (writeTransaction.credentialDefinition) {
+
+        const writeCredDef = await this.submitCredDefOnLedger(writeTransaction.credentialDefinition, writeTransaction.endorsedTransaction, writeTransaction.endorserDid);
+        return writeCredDef;
+      } else {
+
+        throw new Error('Please provide valid schema or credential-def!');
+      }
+
+    } catch (error) {
+      if (error instanceof AriesFrameworkError) {
+        if (error.message.includes('UnauthorizedClientRequest')) {
+          return forbiddenError(400, {
+            reason: 'this action is not allowed.',
+          })
+        }
+      }
+      return internalServerError(500, { message: `something went wrong: ${error}` })
+    }
+  }
+
+  public async submitSchemaOnLedger(
+    schema: {
+      issuerId: string
+      name: string
+      version: Version
+      attributes: string[]
+    },
+    endorsedTransaction?: string,
+    endorserDid?: string
+  ) {
+    try {
+
+      const { schemaState } = await this.agent.modules.anoncreds.registerSchema({
+        options: {
+          endorserMode: 'external',
+          endorsedTransaction
+        },
+        schema: {
+          attrNames: schema.attributes,
+          issuerId: schema.issuerId,
+          name: schema.name,
+          version: schema.version
+        },
+      })
+
+      const getSchemaUnqualifiedId = await getUnqualifiedSchemaId(schemaState.schema.issuerId, schema.name, schema.version);
+      if (schemaState.state === 'finished' || schemaState.state === 'action') {
+        const indyNamespace = /did:indy:([^:]+:?(mainnet|testnet)?:?)/.exec(schema.issuerId);
+        let schemaId;
+        if (indyNamespace) {
+          schemaId = getSchemaUnqualifiedId.substring(`did:indy:${indyNamespace[1]}`.length);
+        } else {
+          throw new Error('No indyNameSpace found')
+        }
+        schemaState.schemaId = schemaId
+      }
+      return schemaState;
+
+    } catch (error) {
+      return error
+    }
+  }
+
+  public async submitCredDefOnLedger(
+    credentialDefinition: {
+      schemaId: string,
+      issuerId: string,
+      tag: string
+    },
+    endorsedTransaction?: string,
+    endorserDid?: string
+  ) {
+    try {
+
+      const { credentialDefinitionState } = await this.agent.modules.anoncreds.registerCredentialDefinition({
+        credentialDefinition,
+        options: {
+          endorserMode: 'external',
+          endorsedTransaction: endorsedTransaction,
+        },
+      })
+
+      const indyVdrAnonCredsRegistry = new IndyVdrAnonCredsRegistry()
+      const schemaDetails = await indyVdrAnonCredsRegistry.getSchema(this.agent.context, credentialDefinition.schemaId)
+      const getCredentialDefinitionId = await getUnqualifiedCredentialDefinitionId(credentialDefinitionState.credentialDefinition.issuerId, `${schemaDetails.schemaMetadata.indyLedgerSeqNo}`, credentialDefinition.tag);
+      if (credentialDefinitionState.state === 'finished' || credentialDefinitionState.state === 'action') {
+
+        const indyNamespaceMatch = /did:indy:([^:]+:?(mainnet|testnet)?:?)/.exec(credentialDefinition.issuerId);
+        let credDefId;
+        if (indyNamespaceMatch) {
+          credDefId = getCredentialDefinitionId.substring(`did:indy:${indyNamespaceMatch[1]}`.length);
+        } else {
+          throw new Error('No indyNameSpace found')
+        }
+
+        credentialDefinitionState.credentialDefinitionId = credDefId;
+      }
+      return credentialDefinitionState;
+
+    } catch (error) {
+      return error
+    }
+  }
+}

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -46,6 +46,7 @@ import type {
 
 
 import type { DIDDocument } from 'did-resolver'
+import { Version } from './examples';
 
 export type TenantConfig = Pick<InitConfig, 'label' | 'connectionImageUrl'> & {
   walletConfig: Pick<WalletConfig, 'id' | 'key' | 'keyDerivationMethod'>;
@@ -308,8 +309,10 @@ export interface DidCreate {
   domain?: string;
   method?: string;
   did?: string;
+  role?: string;
   options?: DidRegistrationExtraOptions;
   secret?: DidRegistrationSecretOptions;
+  endorserDid?: string;
   didDocument?: DidDocument;
 }
 
@@ -317,6 +320,8 @@ export interface CreateTenantOptions {
   config: Omit<TenantConfig, 'walletConfig'>,
   seed: string;
   method?: string;
+  role?: string;
+  endorserDid?: string;
 }
 
 // export type WithTenantAgentCallback<AgentModules extends ModulesMap> = (
@@ -347,4 +352,30 @@ export interface CreateInvitationOptions {
   autoAcceptConnection?: boolean;
   routing?: Routing;
   appendedAttachments?: Attachment[];
+}
+
+export interface EndorserTransaction {
+  transaction: string | Record<string, unknown>,
+  endorserDid: string
+}
+
+export interface DidNymTransaction {
+  did: string
+  nymRequest: string
+}
+
+export interface WriteTransaction {
+  endorserDid?: string
+  endorsedTransaction?: string
+  schema?: {
+    issuerId: string
+    name: string
+    version: Version
+    attributes: string[]
+  },
+  credentialDefinition?: {
+    schemaId: string,
+    issuerId: string,
+    tag: string
+  }
 }


### PR DESCRIPTION
### What ###
Implemented an endorser-policy function for request endorsement and submission.

### Why ###
By implementing an endorser-policy function, we can ensure that requests are endorsed by endorser before they are submitted.

### How ###
I implemented the endorser-policy function using the following steps:
1. **Create-Request API**: I added a new API endpoint that allows users to create requests. This endpoint collects necessary information and generates a unique request identifier.

2. **Endorse (Sign) Request API**: Implemented an API endpoint that allows endorsers to sign and endorse a request. This involves verifying the request details and attaching the endorser signature to the request.

3. **Submit Request API**: Created an API endpoint that enables users to submit a request for processing. This endpoint checks if the request has received the required endorsements and meets the policy criteria before processing it.

This implementation enhances our system's functionality and security, making it more robust and reliable for our users.
