### PR TITLE
fix: add the label on the out-of-band connection

### DIFF
--- a/src/controllers/credentials/CredentialController.ts
+++ b/src/controllers/credentials/CredentialController.ts
@@ -220,7 +220,7 @@ export class CredentialController extends Controller {
 
       const credentialMessage = offerOob.message;
       const outOfBandRecord = await this.agent.oob.createInvitation({
-        label: 'test-connection',
+        label: outOfBandOption.label,
         handshakeProtocols: [HandshakeProtocol.Connections],
         messages: [credentialMessage],
         autoAcceptConnection: true

--- a/src/controllers/proofs/ProofController.ts
+++ b/src/controllers/proofs/ProofController.ts
@@ -193,7 +193,7 @@ export class ProofController extends Controller {
       });
       const proofMessage = proof.message;
       const outOfBandRecord = await this.agent.oob.createInvitation({
-        label: 'test-connection',
+        label: createRequestOptions.label,
         handshakeProtocols: [HandshakeProtocol.Connections],
         messages: [proofMessage],
         autoAcceptConnection: true

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -136,6 +136,7 @@ export interface CreateOfferOobOptions {
   goalCode?: string;
   parentThreadId?: string;
   willConfirm?: boolean;
+  label?: string;
 }
 export interface CredentialCreateOfferOptions {
   credentialRecord: CredentialExchangeRecord;
@@ -152,6 +153,7 @@ export interface CreateProofRequestOobOptions {
   willConfirm?: boolean;
   autoAcceptProof?: AutoAcceptProof;
   comment?: string;
+  label?: string;
 }
 
 export interface OfferCredentialOptions {


### PR DESCRIPTION
### What ###
Add a descriptive label to clearly identify the out-of-band connection in the codebase.

### Why ###
The current code lacks a clear label for the out-of-band connection, making it challenging for developers to understand its purpose and functionality. Adding a label will improve code readability and maintainability.

### How ###
Introduce a meaningful label or comment in the code to describe the out-of-band connection. Ensure that the label is concise but provides sufficient information for other developers to grasp the purpose of this connection.
