### PR TITLE
fix: add the label on the out-of-band connection in mutli-tenancy

### DIFF
--- a/src/cliAgent.ts
+++ b/src/cliAgent.ts
@@ -76,7 +76,10 @@ export type RestAgentModules = Awaited<ReturnType<typeof getModules>>
 const getWithTenantModules = (networkConfig: [IndyVdrPoolConfig, ...IndyVdrPoolConfig[]]) => {
   const modules = getModules(networkConfig)
   return {
-    tenants: new TenantsModule<typeof modules>({}),
+    tenants: new TenantsModule<typeof modules>({
+      sessionAcquireTimeout: Infinity,
+      sessionLimit: Infinity
+    }),
     ...modules
   }
 }

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -864,7 +864,7 @@ export class MultiTenancyController extends Controller {
 
             const credentialMessage = offerOob.message;
             const outOfBandRecord = await tenantAgent.oob.createInvitation({
-                label: 'test-connection',
+                label: createOfferOptions.label,
                 handshakeProtocols: [HandshakeProtocol.Connections],
                 messages: [credentialMessage],
                 autoAcceptConnection: true
@@ -1049,7 +1049,7 @@ export class MultiTenancyController extends Controller {
 
             const proofMessage = proof.message;
             const outOfBandRecord = await tenantAgent.oob.createInvitation({
-                label: 'test-connection',
+                label: createRequestOptions.label,
                 handshakeProtocols: [HandshakeProtocol.Connections],
                 messages: [proofMessage],
                 autoAcceptConnection: true


### PR DESCRIPTION
### What ###
Add a descriptive label to clearly identify the out-of-band connection in the codebase on multi-tenancy.

### Why ###
The current code lacks a clear label for the out-of-band connection, making it challenging for developers to understand its purpose and functionality on multi-tenancy. Adding a label will improve code readability and maintainability.

### How ###
Introduce a meaningful label or comment in the code to describe the out-of-band connection. Ensure that the label is concise but provides sufficient information for other developers to grasp the purpose of this connection.
