### PR TITLE
fix: delete multi-tenancy by tenant Id

### DIFF
--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -1160,7 +1160,7 @@ export class MultiTenancyController extends Controller {
 
     @Get(":tenantId")
     public async getTenantById(
-        @Query("tenantId") tenantId: string,
+        @Path("tenantId") tenantId: string,
         @Res() notFoundError: TsoaResponse<404, { reason: string }>,
         @Res() internalServerError: TsoaResponse<500, { message: string }>
     ) {
@@ -1202,7 +1202,7 @@ export class MultiTenancyController extends Controller {
 
     @Delete(":tenantId")
     public async deleteTenantById(
-        @Query("tenantId") tenantId: string,
+        @Path("tenantId") tenantId: string,
         @Res() notFoundError: TsoaResponse<404, { reason: string }>,
         @Res() internalServerError: TsoaResponse<500, { message: string }>
     ) {


### PR DESCRIPTION
### What ###
Delete multi-tenancy by tenant ID.

### Why ###
Explain the reasons for deleting multi-tenancy by tenant ID. This could include simplifying the codebase, improving performance, or addressing specific issues.

### How ###
Provide a brief overview of the changes made to achieve the deletion of multi-tenancy by tenant ID. Highlight any key modifications or strategies employed.